### PR TITLE
This fixes https://github.com/malclocke/fulcrum/issues/6

### DIFF
--- a/public/javascripts/views/form_view.js
+++ b/public/javascripts/views/form_view.js
@@ -3,7 +3,7 @@ var FormView = Backbone.View.extend({
 
   label: function(elem_id, value) {
     value = value || elem_id;
-    return this.make('label', {for: elem_id}, value);
+    return this.make('label', {'for': elem_id}, value); // for is a reserved word
   },
 
   textField: function(name) {

--- a/public/javascripts/views/story_view.js
+++ b/public/javascripts/views/story_view.js
@@ -219,7 +219,7 @@ var StoryView = FormView.extend({
       div = this.make('div');
       if (!this.model.isNew()) {
         $(div).append(
-          this.make("img", {class: "collapse", src: "/images/collapse.png"})
+          this.make("img", {'class': "collapse", 'src': "/images/collapse.png"})
         );
       }
       $(div).append(this.textField("title"));


### PR DESCRIPTION
passing options objects with 'for' and 'class' breaks in Safari
this commit fixes these 2 cases only
