### PR TITLE
Configure SendGrid for Heroku

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,37 @@ Once you have these:
 You should then be able to navigate to `http://localhost:3000/` in a web browser.
 You can log in with the test username `test@example.com`, password `testpass`.
 
+
+Heroku setup
+------------
+
 If you wish to host a publicly available copy of Fulcrum, the easiest option is
-to host it on [Heroku](http://heroku.com/).  You'll find full instructions on
-setting up Rails applications on their website.
+to host it on [Heroku](http://heroku.com/).
+
+To deploy it to Heroku, make sure you have a local copy of the project; refer 
+to the previous section for instuctions. Then:
+
+    # Make sure you have the Heroku gem
+    $ gem install heroku
+
+    # Create your app. Replace APPNAME with whatever you want to name it.
+    $ heroku create APPNAME --stack bamboo-mri-1.9.2
+   
+    # Define where the user emails will be coming from
+    # (This email address does not need to exist)
+    $ heroku config:add MAILER_SENDER=noreply@example.org
+
+    # Allow emails to be sent
+    $ heroku addons:add sendgrid:free
+
+    # Deploy the first version
+    $ git push heroku master
+
+    # Set up the database
+    $ heroku rake db:setup
+
+Once that's done, you will be able to view your site at 
+`http://APPNAME.heroku.com`.
 
 Development
 -----------

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -3,7 +3,7 @@
 Devise.setup do |config|
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in DeviseMailer.
-  config.mailer_sender = "please-change-me@config-initializers-devise.com"
+  config.mailer_sender = ENV['MAILER_SENDER'] || "please-change-me@config-initializers-devise.com"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = "Devise::Mailer"

--- a/config/initializers/sendgrid.rb
+++ b/config/initializers/sendgrid.rb
@@ -1,0 +1,11 @@
+# Configure Heroku to use SendGrid.
+if ENV['SENDGRID_USERNAME']
+  ActionMailer::Base.smtp_settings = {
+    :address        => "smtp.sendgrid.net",
+    :port           => "25",
+    :authentication => :plain,
+    :user_name      => ENV['SENDGRID_USERNAME'],
+    :password       => ENV['SENDGRID_PASSWORD'],
+    :domain         => ENV['SENDGRID_DOMAIN']
+  }
+end


### PR DESCRIPTION
Deploying the app to Heroku is almost useless because confirmation emails are not sent, hence you can't sign up.

These changes will allow the use of Heroku's SendGrid service when the app is deployed to Heroku. There's a `if ENV['SENDGRID_...']` check in there in the initializer, so it will only affect the app when it's deployed to Heroku.

I've also taken the liberty of adding instructions on how to deploy the app to Heroku. It needs `heroku addons:add sendgrid:free` of course.

This patch also allows you to configure the _From:_ address of the emails that will be sent via an environment variable.
