### PR TITLE
Changed JSON date format to work in Safari

### DIFF
--- a/config/initializers/fulcrum.rb
+++ b/config/initializers/fulcrum.rb
@@ -1,0 +1,1 @@
+ActiveSupport.use_standard_json_time_format = false

--- a/spec/javascripts/models/project.spec.js
+++ b/spec/javascripts/models/project.spec.js
@@ -142,12 +142,12 @@ describe('Project model', function() {
 
     it("should get the right iteration number for a given date", function() {
       // This is a Monday
-      this.project.set({start_date: "2011-07-25"});
+      this.project.set({start_date: "2011/07/25"});
 
-      var compare_date = new Date("2011-07-25");
+      var compare_date = new Date("2011/07/25");
       expect(this.project.getIterationNumberForDate(compare_date)).toEqual(1);
 
-      compare_date = new Date("2011-08-01");
+      compare_date = new Date("2011/08/01");
       expect(this.project.getIterationNumberForDate(compare_date)).toEqual(2);
 
       // With a 2 week iteration length, the date above will still be in
@@ -167,27 +167,27 @@ describe('Project model', function() {
 
     it("should return the start date", function() {
       // Date is a Monday, and day 1 is Monday
-      this.project.set({start_date: "2011-07-25",iteration_start_day: 1});
-      expect(this.project.startDate()).toEqual(new Date("2011-07-25"));
+      this.project.set({start_date: "2011/07/25",iteration_start_day: 1});
+      expect(this.project.startDate()).toEqual(new Date("2011/07/25"));
 
       // If the project start date has been explicitly set to a Thursday, but
       // the iteration_start_day is Monday, the start date should be the Monday
       // that immeadiatly preceeds the Thursday.
-      this.project.set({start_date: "2011-07-28"});
-      expect(this.project.startDate()).toEqual(new Date("2011-07-25"));
+      this.project.set({start_date: "2011/07/28"});
+      expect(this.project.startDate()).toEqual(new Date("2011/07/25"));
 
       // The same, but this time the iteration start day is 'after' the start
       // date day, in ordinal terms, e.g. iteration start date is a Saturday,
       // project start date is a Thursday.  The Saturday prior to the Thursday
       // should be returned.
       this.project.set({iteration_start_day: 6});
-      expect(this.project.startDate()).toEqual(new Date("2011-07-23"));
+      expect(this.project.startDate()).toEqual(new Date("2011/07/23"));
 
       // If the project start date is not set, it should be considered as the
       // first iteration start day prior to today.
       // FIXME - Stubbing Date is not working
-      var expected_date = new Date('2011-07-23');
-      var fake_today = new Date('2011-07-29');
+      var expected_date = new Date('2011/07/23');
+      var fake_today = new Date('2011/07/29');
       orig_date = Date;
       Date = sinon.stub().returns(fake_today);
       this.project.unset('start_date');

--- a/spec/javascripts/models/story.spec.js
+++ b/spec/javascripts/models/story.spec.js
@@ -92,9 +92,9 @@ describe('Story model', function() {
     });
 
     it("should not set accepted at when accepted if already set", function() {
-      this.story.set({accepted_at: "2001-01-01"});
+      this.story.set({accepted_at: "2001/01/01"});
       this.story.accept();
-      expect(this.story.get('accepted_at')).toEqual("2001-01-01");
+      expect(this.story.get('accepted_at')).toEqual("2001/01/01");
     });
 
   });
@@ -261,7 +261,7 @@ describe('Story model', function() {
 
     it("should return the iteration number for an accepted story", function() {
       this.story.collection.project.getIterationNumberForDate = sinon.stub().returns(999);
-      this.story.set({accepted_at: "2011-07-25", state: "accepted"});
+      this.story.set({accepted_at: "2011/07/25", state: "accepted"});
       expect(this.story.iterationNumber()).toEqual(999);
     });
 

--- a/test/unit/story_test.rb
+++ b/test/unit/story_test.rb
@@ -138,7 +138,7 @@ class StoryTest < ActiveSupport::TestCase
   end
 
   test "should not set accepted at when accepted if already set" do
-    date = @story.accepted_at = Date.parse('1999-01-01')
+    date = @story.accepted_at = Date.parse('1999/01/01')
     @story.update_attribute :state, 'accepted'
     assert_equal date, @story.accepted_at
   end
@@ -153,8 +153,8 @@ class StoryTest < ActiveSupport::TestCase
   # If a story has an accepted date prior to the project start date,
   # reset the project start date
   test "should set project start date if accepted at is prior" do
-    @project.start_date = Date.parse('2001-01-02')
-    @story.update_attribute :accepted_at, Date.parse('2001-01-01')
+    @project.start_date = Date.parse('2001/01/02')
+    @story.update_attribute :accepted_at, Date.parse('2001/01/01')
     assert_equal @story.accepted_at, @project.start_date
   end
 


### PR DESCRIPTION
Changed JSON date format to work in Safari.
Fixes issue #8 and issue #12.
