### PR TITLE
Fix for set password

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -1,0 +1,14 @@
+class ConfirmationsController < Devise::ConfirmationsController
+  # GET /resource/confirmation?confirmation_token=abcdef
+  def show
+    self.resource = resource_class.confirm_by_token(params[:confirmation_token])
+    
+    if resource.errors.empty?
+      set_flash_message :notice, :confirmed
+      redirect_to edit_user_password_path(:reset_password_token => resource.reset_password_token)
+    else
+      render_with_scope :new
+    end
+  end
+
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,7 +17,7 @@ class User < ActiveRecord::Base
 
   has_and_belongs_to_many :projects, :uniq => true
 
-  before_validation :set_random_password_if_blank
+  before_validation :set_random_password_if_blank, :set_reset_password_token
 
   validates :name, :presence => true
   validates :initials, :presence => true
@@ -29,6 +29,12 @@ class User < ActiveRecord::Base
   def set_random_password_if_blank
     if new_record? && self.password.blank? && self.password_confirmation.blank?
       self.password = self.password_confirmation = Digest::SHA1.hexdigest("--#{Time.now.to_s}--#{email}--")[0,6]
+    end
+  end
+
+  def set_reset_password_token
+    if new_record?
+      self.reset_password_token = Devise.friendly_token
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,7 @@ Fulcrum::Application.routes.draw do
     end
   end
 
-  devise_for :users
+  devise_for :users, :controllers => { :confirmations => "confirmations" }
 
   # The priority is based upon order of creation:
   # first created -> highest priority.

--- a/test/functional/confirmations_controller_test.rb
+++ b/test/functional/confirmations_controller_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class ConfirmationsControllerTest < ActionController::TestCase
+  include Devise::TestHelpers
+  
+  def setup
+    @request.env['devise.mapping'] = Devise.mappings[:user]
+  end
+  test "should be able to change password after confirmation" do
+    user = Factory.create(:user, :reset_password_token => 'fdsedf4343334ik3hhudfug')
+    user.confirmed_at = nil
+    user.confirmation_token = Devise.friendly_token
+    user.confirmation_sent_at = Time.now.utc
+    user.save(:validate => false)
+
+    get :show, :confirmation_token => user.confirmation_token
+    assert_redirected_to(edit_user_password_path(:reset_password_token => user.reset_password_token))
+  end
+end


### PR DESCRIPTION
When a new user was invited from project management, it was not allowing to change his password, it was prompting for 'previous' password, but it's random generated.
