### PR TITLE
Using respond_to with a flash_responder and removed some XML routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ Once you have these:
     # Checkout the project
     $ git clone git://github.com/malclocke/fulcrum.git
     $ cd fulcrum
-    $ git checkout rails3.1
 
     # Install the project dependencies
     $ gem install bundler

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
+require 'flash_responder'
 class ApplicationController < ActionController::Base
   protect_from_forgery
-
+  self.responder = FlashResponder
   before_filter :authenticate_user!
 
   # Handle unauthorized access with a good old fashioned 'forbidden'

--- a/app/controllers/changesets_controller.rb
+++ b/app/controllers/changesets_controller.rb
@@ -1,10 +1,12 @@
 class ChangesetsController < ApplicationController
+  respond_to :json
+
   def index
     @project = current_user.projects.find(params[:project_id])
     scope = @project.changesets.scoped
     scope = scope.where('id <= ?', params[:to]) if params[:to]
     scope = scope.where('id > ?', params[:from]) if params[:from]
     @changesets = scope
-    render :json => @changesets
+    respond_with @changesets
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,99 +1,50 @@
 class ProjectsController < ApplicationController
+  respond_to :html, :json
 
-  # GET /projects
-  # GET /projects.xml
   def index
     @projects = current_user.projects
-    respond_to do |format|
-      format.html # index.html.erb
-      format.xml  { render :xml => @projects }
-    end
+    respond_with @projects
   end
 
-  # GET /projects/1
-  # GET /projects/1.xml
   def show
     @project = current_user.projects.find(params[:id])
     @story = @project.stories.build
-
-    respond_to do |format|
-      format.html # show.html.erb
-      format.js   { render :json => @project }
-      format.xml  { render :xml => @project }
-    end
+    respond_with @project
   end
 
-  # GET /projects/new
-  # GET /projects/new.xml
   def new
     @project = Project.new
-
-    respond_to do |format|
-      format.html # new.html.erb
-      format.xml  { render :xml => @project }
-    end
+    respond_with @project
   end
 
-  # GET /projects/1/edit
   def edit
     @project = current_user.projects.find(params[:id])
     @project.users.build
+    respond_with @project
   end
 
-  # POST /projects
-  # POST /projects.xml
   def create
     @project = current_user.projects.build(params[:project])
     @project.users << current_user
-
-    respond_to do |format|
-      if @project.save
-        format.html { redirect_to(@project, :notice => 'Project was successfully created.') }
-        format.xml  { render :xml => @project, :status => :created, :location => @project }
-      else
-        format.html { render :action => "new" }
-        format.xml  { render :xml => @project.errors, :status => :unprocessable_entity }
-      end
-    end
+    @project.save
+    respond_with @project
   end
 
-  # PUT /projects/1
-  # PUT /projects/1.xml
   def update
     @project = current_user.projects.find(params[:id])
-
-    respond_to do |format|
-      if @project.update_attributes(params[:project])
-        format.html { redirect_to(@project, :notice => 'Project was successfully updated.') }
-        format.xml  { head :ok }
-      else
-        format.html { render :action => "edit" }
-        format.xml  { render :xml => @project.errors, :status => :unprocessable_entity }
-      end
-    end
+    @project.update_attributes(params[:project])
+    respond_with @project
   end
 
-  # DELETE /projects/1
-  # DELETE /projects/1.xml
   def destroy
     @project = current_user.projects.find(params[:id])
     @project.destroy
-
-    respond_to do |format|
-      format.html { redirect_to(projects_url) }
-      format.xml  { head :ok }
-    end
+    respond_with(@project, :location => projects_url)
   end
 
-  # GET /projects/1/users
-  # GET /projects/1/users.xml
   def users
     @project = current_user.projects.find(params[:id])
     @users = @project.users
-
-    respond_to do |format|
-      format.html # users.html.erb
-      format.xml  { render :xml => @project }
-    end
+    respond_with(@project)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -25,13 +25,16 @@ class UsersController < ApplicationController
     end
 
     if @project.users.include?(@user)
-      flash[:alert] = "#{@user.email} is already a member of this project"
+      flash[:alert] = I18n.t( 'create.existing', :email => @user.email,
+                              :scope => [:flash, :users, :actions])
     else
       @project.users << @user
       if @user.was_created
-        flash[:notice] = "#{@user.email} was sent an invite to join this project"
+        flash[:notice] = I18n.t( 'create.invited', :email => @user.email,
+                                  :scope => [:flash, :users, :actions])
       else
-        flash[:notice] = "#{@user.email} was added to this project"
+        flash[:notice] = I18n.t( 'create.added', :email => @user.email,
+                                  :scope => [:flash, :users, :actions])
       end
     end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,3 +39,18 @@ en:
   time:
     formats:
       note_date: "%b %d, %Y"
+
+  flash:
+    actions:
+      create: '%{resource} was successfully created'
+      update: '%{resource} was successfully updated'
+      destroy: '%{resource} was successfully destroyed'
+    projects:
+      actions:
+        create: "Project was successfully created"
+    users:
+      actions:
+        create:
+          existing: "%{email} is already a member of this project"
+          added: "%{email} was added to this project"
+          invited: "%{email} was sent an invite to join this project"

--- a/lib/flash_responder.rb
+++ b/lib/flash_responder.rb
@@ -1,0 +1,21 @@
+class FlashResponder < ActionController::Responder
+  def to_html
+    unless get? || has_errors? || options.delete(:flash) == false
+      namespace = controller.controller_path.split('/')
+      namespace << controller.action_name
+      controller.flash[:notice] ||= I18n.t(namespace.join("."), :scope => :flash,
+      :default => "actions.#{controller.action_name}".to_sym, :resource => resource.class.model_name.human)
+    end
+    super
+  end
+
+  protected
+
+    def api_behavior(error)
+      if put?
+        display resource, :status => :ok
+      else
+        super(error)
+      end
+    end
+end

--- a/test/functional/projects_controller_test.rb
+++ b/test/functional/projects_controller_test.rb
@@ -39,6 +39,12 @@ class ProjectsControllerTest < ActionController::TestCase
     end
   end
 
+  test "should set flash on create" do
+    sign_in @user
+    post :create, :project => @project.attributes
+    assert_equal "Project was successfully created", flash[:notice]
+  end
+
   test "should show project" do
     sign_in @user
     get :show, :id => @project.to_param
@@ -49,7 +55,7 @@ class ProjectsControllerTest < ActionController::TestCase
 
   test "should show project in js format" do
     sign_in @user
-    get :show, :id => @project.to_param, :format => 'js'
+    get :show, :id => @project.to_param, :format => 'json'
     assert_equal @project, assigns(:project)
     assert_response :success
   end
@@ -79,6 +85,12 @@ class ProjectsControllerTest < ActionController::TestCase
     attributes[:name] = ''
     put :update, :id => @project.to_param, :project => attributes
     assert_response :success
+  end
+
+  test "should set flash on update" do
+    sign_in @user
+    put :update, :id => @project.to_param, :project => @project.attributes
+    assert_equal "Project was successfully updated", flash[:notice]
   end
 
   test "should destroy project" do

--- a/test/functional/stories_controller_test.rb
+++ b/test/functional/stories_controller_test.rb
@@ -23,7 +23,7 @@ class StoriesControllerTest < ActionController::TestCase
     sign_in @user
     assert_difference 'Story.count' do
       xhr :post, :create, :project_id => @project.to_param,
-        :story => {:title => 'Test title', :editing => true}
+        :story => {:title => 'Test title', :editing => true}, :format => :json
     end
     assert_equal @user, assigns(:story).requested_by
     assert_equal @project, assigns(:project)
@@ -123,7 +123,7 @@ class StoriesControllerTest < ActionController::TestCase
   test "should update a story via xhr" do
     sign_in @user
     xhr :put, :update, :id => @story.to_param, :project_id => @project.to_param,
-      :story => {:title => "Updated title", :estimate => 1}
+      :story => {:title => "Updated title", :estimate => 1}, :format => :json
     assert_response :success
     assert_equal @project, assigns(:project)
     assert_equal @story, assigns(:story)


### PR DESCRIPTION
Move controller text to en.yml and add a custom flash responder

use responders globally

don't overwrite an existing flash message

need to be more specific with tests now that the xml routes have been removed

add destroy message

Need to override standard rails responder as it defaults to returning an empty hash on update

Responder will handle destroy actions correctly too