### PR TITLE
Rake setup tasks

### DIFF
--- a/lib/tasks/fulcrum.rake
+++ b/lib/tasks/fulcrum.rake
@@ -5,7 +5,7 @@ namespace :fulcrum do
     file    = Rails.root.join('config',"database.yml")
 
     unless File.exists?(file)
-      sh "cp #{example_file} #{file}"
+      sh "cp '#{example_file}' '#{file}'"
     else
       puts "#{file} already exists!"
     end


### PR DESCRIPTION
Wrapped the cp arguments in ' to avoid problems when the app is being set up in a directory whose path contains spaces.
