### PR TITLE
Add Letter_opener and simplecover plugins, fixed 1 test, fixed 1 spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ log/*.log
 tmp/**/*
 .rvmrc
 public/stylesheets/*
+coverage/*

--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,10 @@ gem 'compass', '>= 0.11.5'
 #   gem 'webrat'
 # end
 
+gem 'simplecov', :require => false, :group => :test
+
 group :development, :test do
   gem 'factory_girl_rails'
   gem 'jasmine', '1.1.0'
+  gem "letter_opener"
 end

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Fulcrum is built with the following Open Source technologies:
 * [Tango Icon Library](http://tango.freedesktop.org/Tango_Icon_Library)
 * [Jasmine](http://pivotal.github.com/jasmine/)
 * [Sinon](http://sinonjs.org/)
+* [Simplecov](http://github.com/colszowka/simplecov/)
 
 License
 -------

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -15,8 +15,8 @@ Fulcrum::Application.configure do
   config.action_controller.perform_caching = false
 
   # Don't care if the mailer can't send
-  config.action_mailer.perform_deliveries = false
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.raise_delivery_errors = true
   config.action_mailer.default_url_options = { :host => '127.0.0.1:3000' }
 
   # Print deprecation notices to the Rails logger
@@ -24,5 +24,7 @@ Fulcrum::Application.configure do
 
   # Only use best-standards-support built into browsers
   config.action_dispatch.best_standards_support = :builtin
+
+  config.action_mailer.delivery_method = :letter_opener
 end
 

--- a/spec/javascripts/models/story.spec.js
+++ b/spec/javascripts/models/story.spec.js
@@ -253,7 +253,7 @@ describe('Story model', function() {
     it("should return a readable created_at", function() {
 
       this.story.set({'created_at': "2011/09/19 02:25:56 +0000"});
-      expect(this.story.created_at()).toBe("19 Sep 2011, 2:25pm");
+      expect(this.story.created_at()).toBe("18 Sep 2011, 10:25pm");
 
     });
 

--- a/test/functional/stories_controller_test.rb
+++ b/test/functional/stories_controller_test.rb
@@ -194,7 +194,7 @@ class StoriesControllerTest < ActionController::TestCase
     end
 
     assert_equal @project, assigns(:project)
-    assert_equal "Unable to import CSV: Illegal quoting on line 1.", flash[:alert]
+    assert_equal "Unable to import CSV: Illegal quoting in line 1.", flash[:alert]
     assert_response :success
     assert_template 'import'
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,6 @@
+require 'simplecov'
+SimpleCov.start
+
 ENV["RAILS_ENV"] = "test"
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'


### PR DESCRIPTION
1. Changed Gemfile and config/environments/development.rb to
   implement letter_opener at https://github.com/ryanb/letter_opener.
2. See 2 SASS::Compiler warnings associated with compass.
   Probably need compass 0.12-alpha.
3. See 1 "Unable to import CSV" error - need to change "on" to "in".
   Changed one line fulcrum/test/functional/stories_controller_test.rb
4. See 1 jasmine error - expected "2011/09/19 02:25:56" but got
   "19 Sep 2011, 10:25am".  Using Chrome.
   Changed one line to "18 Sep 2011, 10:25pm" in
   fulcrum/spec/javascripts/models/story.spec.js.
   Now all 177 specs pass in 1.069s
5. Changed Gemfile and test/test_helper.rb based on simplecov README.
       https://github.com/colszowka/simplecov#readme
6. Added "coverage/*" to .gitignore so I did not check in coverage data.
7.  Fixed test/functional/stories_controller_test.rb (1 character change).
8. Added simplecov to README.md tool list.
9. FYI: 1st test suite has 77.75% coverage and 2nd test suite has 94.92%.
   Decide to stop and not add tests as part of this pull request (keep it small).
