### PR TITLE
Fix story created_at issue in Jasmine test suite

### DIFF
--- a/spec/javascripts/models/story.spec.js
+++ b/spec/javascripts/models/story.spec.js
@@ -252,7 +252,7 @@ describe('Story model', function() {
 
     it("should return a readable created_at", function() {
 
-      this.story.set({'created_at': "2011/09/19 02:25:56 +0000"});
+      this.story.set({'created_at': "2011/09/19 14:25:56"});
       expect(this.story.created_at()).toBe("19 Sep 2011, 2:25pm");
 
     });


### PR DESCRIPTION
Date formatter on story converts +0000 to local time for display causing a mismatch for anyone not in GMT
