### PR TITLE
removed annoying title attribute from details icon

### DIFF
--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -23,7 +23,7 @@
     class="icon icons-${story.story_type} story_type"
     title="${story.story_type}: ${story.id}">${story.story_type}</span>{{if story.estimated}}<span
     class="estimate estimate_${story.estimate}">${story.estimate}</span>{{/if}}{{if $item.story.hasDetails()}}<span
-    class="icon icons-details" title="${story.description}"></span>{{/if}}</span></div>
+    class="icon icons-details"></span>{{/if}}</span></div>
   <div class="story-title">
     {{if story.labels}}<span class="tags">${story.labels}</span>{{/if}}
     ${story.title}


### PR DESCRIPTION
Hi Malcolm,

the little title attribute popup is a little bit annoying, so I would suggest to drop it.

I like fulcrum very much, many thanks for your work!

many greetings from Bremen, Germany

Ecki
