### PR TITLE
Tweaks to get it working under Passenger

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ Once you have these:
 You should then be able to navigate to `http://localhost:3000/` in a web browser.
 You can log in with the test username `test@example.com`, password `testpass`.
 
+Passenger Setup
+---------------
+
+If you are deploying to a production environment under Passenger, you may need to
+pre-compile your assets to avoid errors:
+
+    $ rake assets:precompile
+
+In addition, you will want to configure 'config.action_mailer.default_url_options'
+in config/environments/production.rb and 'config.mailer_sender' in 
+config/initializers/devise.rb to ensure that user signup confirmation emails are sent.
 
 Heroku setup
 ------------
@@ -147,7 +158,7 @@ Fulcrum is built with the following Open Source technologies:
 
 License
 -------
-Copyright 2011, Malcolm Locke.
+Copyright 2012, Malcolm Locke.
 
 Fulcrum is made available under the Affero GPL license version 3, see
 LICENSE.txt.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,6 +35,7 @@ class User < ActiveRecord::Base
   def set_reset_password_token
     if new_record?
       self.reset_password_token = Devise.friendly_token
+      self.reset_password_sent_at = Time.now
     end
   end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,6 +48,7 @@ Fulcrum::Application.configure do
   # Disable delivery errors, bad email addresses will be ignored
   # config.action_mailer.raise_delivery_errors = false
   config.action_mailer.default_url_options = { :host => "#{ENV['APP_NAME']}.heroku.com" }
+  config.action_mailer.smtp_settings = {:enable_starttls_auto => false }
 
   # Enable threaded mode
   # config.threadsafe!

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,21 +11,21 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120319114057) do
+ActiveRecord::Schema.define(:version => 20111009095221) do
 
   create_table "changesets", :force => true do |t|
     t.integer  "story_id"
     t.integer  "project_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
   end
 
   create_table "notes", :force => true do |t|
     t.text     "note"
     t.integer  "user_id"
     t.integer  "story_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
   end
 
   create_table "projects", :force => true do |t|
@@ -34,8 +34,8 @@ ActiveRecord::Schema.define(:version => 20120319114057) do
     t.date     "start_date"
     t.integer  "iteration_start_day", :default => 1
     t.integer  "iteration_length",    :default => 1
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                                   :null => false
+    t.datetime "updated_at",                                   :null => false
     t.integer  "default_velocity",    :default => 10
   end
 
@@ -54,8 +54,8 @@ ActiveRecord::Schema.define(:version => 20120319114057) do
     t.integer  "requested_by_id"
     t.integer  "owned_by_id"
     t.integer  "project_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                               :null => false
+    t.datetime "updated_at",                               :null => false
     t.decimal  "position"
     t.string   "labels"
   end
@@ -64,7 +64,7 @@ ActiveRecord::Schema.define(:version => 20120319114057) do
     t.string   "email",                                 :default => "",   :null => false
     t.string   "encrypted_password",     :limit => 128, :default => "",   :null => false
     t.string   "reset_password_token"
-    t.string   "remember_token"
+    t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
     t.integer  "sign_in_count",                         :default => 0
     t.datetime "current_sign_in_at"
@@ -75,14 +75,13 @@ ActiveRecord::Schema.define(:version => 20120319114057) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string   "password_salt"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                                              :null => false
+    t.datetime "updated_at",                                              :null => false
     t.string   "name"
     t.string   "initials"
     t.boolean  "email_delivery",                        :default => true
     t.boolean  "email_acceptance",                      :default => true
     t.boolean  "email_rejection",                       :default => true
-    t.datetime "reset_password_sent_at"
   end
 
   add_index "users", ["confirmation_token"], :name => "index_users_on_confirmation_token", :unique => true

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,7 +16,6 @@ describe User do
 
   end
 
-
   describe "#to_s" do
 
     subject { Factory.build(:user, :name => "Dummy User", :initials => "DU",
@@ -36,6 +35,16 @@ describe User do
       subject.as_json['user'].keys.sort.should == %w[email id initials name]
     }
 
+  end
+
+  describe "reset_password_sent_at default" do
+    subject do
+      user = Factory.build(:unconfirmed_user)
+      user.valid?
+      user
+    end
+
+    its(:reset_password_sent_at) { should_not be_nil }
   end
 
 end


### PR DESCRIPTION
Hi, I have a proposed set of tweaks to get this working under Passenger, including some documentation changes.

I was getting a persistent error with the confirmation process complaining about a missing reset_password_sent_at field, so I added a spec for it and tweaked the User model slightly.

Finally, I didn't commit this as I'm not sure the right way to do it, but: the most recent migration seems to be redundant if you are setting up from scratch, as the most recent version of Devise includes this field (actually the aforementioned reset_password_sent_at field).

I thought about that migration and I don't know the right way to handle it.  Those folks who are upgrading may need it for Devise to function, but it breaks the install process for those of us who set up our own database config (in my case, using Postgres) and migrate with a "from scratch" install.  Breaks the tests as well.  How to handle?
