### PR TITLE
Rename heroku.com to herokuapp.com. because Heroku default domain

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,7 +47,7 @@ Fulcrum::Application.configure do
 
   # Disable delivery errors, bad email addresses will be ignored
   # config.action_mailer.raise_delivery_errors = false
-  config.action_mailer.default_url_options = { :host => "#{ENV['APP_NAME']}.heroku.com" }
+  config.action_mailer.default_url_options = { :host => "#{ENV['APP_NAME']}.herokuapp.com" }
 
   # Enable threaded mode
   # config.threadsafe!


### PR DESCRIPTION
changed herokuapp.com
