### PR TITLE
Fix issue where password change after initial confirmation fails

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,7 +35,7 @@ class User < ActiveRecord::Base
 
   def set_reset_password_token
     if new_record?
-      self.reset_password_token = Devise.friendly_token
+      generate_reset_password_token!
     end
   end
 

--- a/spec/requests/confirmations_spec.rb
+++ b/spec/requests/confirmations_spec.rb
@@ -25,7 +25,6 @@ describe "Confirmations" do
     # their confirmation token from the database.
     ActionMailer::Base.deliveries.last.to.should include 'test@example.com'
     user = User.find_by_email('test@example.com')
-    user.update_attribute(:reset_password_sent_at, Time.now)
     visit '/users/confirmation?confirmation_token=' + user.confirmation_token
     page.should have_content('Your account was successfully confirmed')
 


### PR DESCRIPTION
...due to expired password reset token.

Weird issue I noticed when setting up an instance. Every person who I invited to the project experienced an expired password reset token after confirming. A quick look at the code showed that callback was setting the password reset token but not the "sent at" field resulting in an invalid token. 

Also the integration that was testing the confirm/password flow was manually setting the sent at column so it probably wasn't being identified.

This changes the setting of the reset_token to the protected method that handles everything properly and removes the masking code from the integration test.
