### PR TITLE
sqlite3 gem also required for production, not only for development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'transitions', '0.0.9', :require => ["transitions", "active_record/transitio
 gem 'i18n-js'
 gem 'rails-i18n'
 gem 'configuration'
+gem 'sqlite3'
 
 gem 'fastercsv', '1.5.3', :platforms => :ruby_18
 # (using standard csv lib if ruby version is 1.9)
@@ -27,7 +28,6 @@ group :production do
 end
 
 group :development, :test do
-  gem 'sqlite3'
   gem 'rspec-rails'
   gem 'factory_girl_rails'
   gem 'jasmine', '1.1.0'


### PR DESCRIPTION
otherwise, the following commands

```
bundle install --without development test
bundle exec rake fulcrum:setup db:setup
```

fail with

```
rake:23:in `<main>'
Couldn't create database for {"adapter"=>"sqlite3", "database"=>"db/test.sqlite3", "pool"=>5, "timeout"=>5000}
rake aborted!
Please install the sqlite3 adapter: `gem install activerecord-sqlite3-adapter` (sqlite3 is not part of the bundle. Add it to Gemfile.)
```
