### PR TITLE
jquery-rails 2.2.x break fulcrum

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :assets do
   gem 'ejs'
 end
 
-gem 'jquery-rails'
+gem 'jquery-rails', "~> 2.1.4"
 
 gem 'devise', "~> 2.0.5"
 gem 'transitions', '0.0.9', :require => ["transitions", "active_record/transitions"]


### PR DESCRIPTION
jquery-rails 2.2 brings in the jQuery 1.9 series. One change that this
release brings is the removal of the jQuery.browser objectAs a
consequence, using jquery-rails 2.2 will cause a TypeError in the
javascript for fulcrum.

This change to the Gemfile cause us to select the most recent release of
jquery-rails on the 2.1.x series, starting with at least v2.1.4
