### PR TITLE
Prevent migration crashes on new install

### DIFF
--- a/db/migrate/20120319114057_add_reset_password_sent_at_to_users.rb
+++ b/db/migrate/20120319114057_add_reset_password_sent_at_to_users.rb
@@ -1,6 +1,8 @@
 class AddResetPasswordSentAtToUsers < ActiveRecord::Migration
   def change
-    add_column :users, :reset_password_sent_at, :datetime
+    if !column_exists?(:users, :reset_password_sent_at)
+      add_column :users, :reset_password_sent_at, :datetime
+    end
 
   end
 end


### PR DESCRIPTION
Seems that devise 2.0 already add the field `:reset_password_sent_at`, so on new installation migration fails because column already exists on database
