### PR TITLE
Description field not importing

### DIFF
--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -83,8 +83,8 @@ $(function() {
     <tr>
       <td class="done_column" style="width: 25%"></td>
       <td class="in_progress_column" style="width: 25%"></td>
-      <td class="chilly_bin_column" style="width: 25%"></td>
       <td class="backlog_column" style="width: 25%"></td>
+      <td class="chilly_bin_column" style="width: 25%"></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
I had a problem with the Description field not importing properly, it was missing from the from_csv() method. Added it, works great.
