### PR TITLE
Added a config switch and logic check to switch the order of the columns for project data

### DIFF
--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -81,10 +81,17 @@ $(function() {
 <table class="stories" width="100%">
   <tbody>
     <tr>
+    <% if !Fulcrum::Application.config.fulcrum.column_order or Fulcrum::Application.config.fulcrum.column_order != 'progress_to_right' %>
       <td class="done_column" style="width: 25%"></td>
       <td class="in_progress_column" style="width: 25%"></td>
       <td class="backlog_column" style="width: 25%"></td>
       <td class="chilly_bin_column" style="width: 25%"></td>
+    <% elsif Fulcrum::Application.config.fulcrum.column_order == 'progress_to_right' %>
+      <td class="chilly_bin_column" style="width: 25%"></td>
+      <td class="backlog_column" style="width: 25%"></td>
+      <td class="in_progress_column" style="width: 25%"></td>
+      <td class="done_column" style="width: 25%"></td>
+    <% end %>
     </tr>
   </tbody>
 </table>

--- a/config/fulcrum_defaults.rb
+++ b/config/fulcrum_defaults.rb
@@ -7,4 +7,9 @@ Configuration.for('fulcrum') do
 
   # Disable registration pages
   disable_registration ENV['DISABLE_REGISTRATION'] || false
+
+  # Project column order:
+  # progress_to_right: chilly bin, backlog, in progress, done
+  # progress_to_left: done, in progress, backlog, chilly bin
+  column_order 'progress_to_left'
 end


### PR DESCRIPTION
Some people like to work left-to-right instead of right-to-left, and now you'll have the option via a config/fulcrum_defaults.rb setting to choose whether you want your columns in "done", "in progress", "backlog", "chilly bin", or the opposite order with the "done" column on the right and so on.
