### PR TITLE
Case-insensitive imports

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -50,7 +50,7 @@ class Project < ActiveRecord::Base
         story = create({
           :state        => row_attrs["Current State"].downcase,
           :title        => row_attrs["Story"],
-          :story_type   => row_attrs["Story Type"],
+          :story_type   => row_attrs["Story Type"].downcase,
           :requested_by => users.detect {|u| u.name == row["Requested By"]},
           :owned_by     => users.detect {|u| u.name == row["Owned By"]},
           :accepted_at  => row_attrs["Accepted at"],

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -134,18 +134,26 @@ describe Project do
   end
 
   describe 'CSV import' do
-    it 'converts state to lowercase before creating the story' do
-      project = FactoryGirl.create :project
-      user = FactoryGirl.create :user
-      project.users << user
+    let(:project) { FactoryGirl.create :project }
+    let(:user) do
+      FactoryGirl.create(:user).tap do |user|
+        # project.users << user
+      end
+    end
+    let(:csv_string) { "Title,Story Type,Requested By,Owned By,Current State\n" }
 
-      csv_string = <<-CSV
-Title,Requested By,Owned By,Current State
-My Story,#{user.name},#{user.name},Accepted
-      CSV
+    it 'converts state to lowercase before creating the story' do
+      csv_string << "My Story,feature,#{user.name},#{user.name},Accepted"
 
       project.stories.from_csv csv_string
       project.stories.first.state.should == 'accepted'
+    end
+
+    it 'converts story type to lowercase before creating the story' do
+      csv_string << "My Story,Chore,#{user.name},#{user.name},unscheduled"
+
+      project.stories.from_csv csv_string
+      project.stories.first.story_type.should == 'chore'
     end
   end
 


### PR DESCRIPTION
Remove case-sensitivity on state and story type when importing from CSV.

Note that I hope to move the CSV import code out of the Project class in order to make it more easily unit-testable. Would that be more convenient in this pull request, or as a separate one?
