### PR TITLE
Install guard and byebug for development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ group :development, :test do
   gem 'byebug'
   gem 'sqlite3'
   gem 'guard-rspec'
+  gem 'guard-jasmine'
   gem 'rspec-rails'
   gem 'factory_girl_rails'
   gem 'jasmine', '~> 1.3.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,12 @@ GEM
       lumberjack (~> 1.0)
       pry (>= 0.9.12)
       thor (>= 0.18.1)
+    guard-jasmine (1.19.0)
+      childprocess
+      guard (>= 2.0.0)
+      multi_json
+      thor
+      tilt
     guard-rspec (4.0.3)
       guard (>= 2.1.1)
       rspec (~> 2.14)
@@ -228,6 +234,7 @@ DEPENDENCIES
   devise (~> 3.2.0)
   ejs
   factory_girl_rails
+  guard-jasmine
   guard-rspec
   i18n-js
   jasmine (~> 1.3.2)

--- a/Guardfile
+++ b/Guardfile
@@ -22,3 +22,10 @@ guard :rspec do
   watch(%r{^spec/acceptance/steps/(.+)_steps\.rb$})   { |m| Dir[File.join("**/#{m[1]}.feature")][0] || 'spec/acceptance' }
 end
 
+
+guard :jasmine do
+  watch(%r{spec/javascripts/spec\.(js\.coffee|js|coffee)$}) { 'spec/javascripts' }
+  watch(%r{spec/javascripts/.+_spec\.(js\.coffee|js|coffee)$})
+  watch(%r{spec/javascripts/fixtures/.+$})
+  watch(%r{app/assets/javascripts/(.+?)\.(js\.coffee|js|coffee)(?:\.\w+)*$}) { |m| "spec/javascripts/#{ m[1] }_spec.#{ m[2] }" }
+end


### PR DESCRIPTION
Everything's easier with Guard and Byebug! I suggest making them development dependencies.
