### PR TITLE
remove garbage dependencies ...

### DIFF
--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -25,7 +25,7 @@ class Story < ActiveRecord::Base
   belongs_to :owned_by, :class_name => 'User'
   validates :owned_by_id, :belongs_to_project => true
 
-  has_many :changesets
+  has_many :changesets, :dependent => :destroy
   has_many :notes do
 
     # Creates a collection of rows on this story from a CSV::Row instance


### PR DESCRIPTION
After any story is removed, the app show garbages about the removed story. This happened because the dependencies of stories is loaded .. To correct that only put ":dependent => :destroy" in changests references on Story model.
