### PR TITLE
fix pivotal import (they renamed fields)

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -49,8 +49,8 @@ class Project < ActiveRecord::Base
         row_attrs = row.to_hash
         story = create({
           :state        => row_attrs["Current State"].downcase,
-          :title        => row_attrs["Story"],
-          :story_type   => row_attrs["Story Type"].downcase,
+          :title        => row_attrs["Title"] || row_attrs["Story"],
+          :story_type   => (row_attrs["Type"] || row_attrs["Story Type"]).downcase,
           :requested_by => users.detect {|u| u.name == row["Requested By"]},
           :owned_by     => users.detect {|u| u.name == row["Owned By"]},
           :accepted_at  => row_attrs["Accepted at"],


### PR DESCRIPTION
Hi, I just did export from our pivotal and noticed fulcrum didn't import it.

Quick fix - pivotal renamed the fields at some point. I added them while keeping backward compatibility in case anyone uses the old format, or keeps the old exports around.

This is my first PR, let me know if I should change anything.
