### PR TITLE
Replace a deprecated method

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,7 +12,7 @@ class UsersController < ApplicationController
   def create
     @project = current_user.projects.find(params[:project_id])
     @users = @project.users
-    @user = User.find_or_create_by_email(params[:user][:email]) do |u|
+    @user = User.find_or_create_by(email: params[:user][:email]) do |u|
       # Set to true if the user was not found
       u.was_created = true
       u.name = params[:user][:name]

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -66,7 +66,7 @@ describe UsersController do
         }}
 
         before do
-          User.stub(:find_or_create_by_email).with(user_params["email"]) { user }
+          User.stub(:find_or_create_by).with(email: user_params["email"]) { user }
         end
 
         specify do
@@ -80,7 +80,7 @@ describe UsersController do
           before do
             user.stub(:new_record? => true)
             user.stub(:save => true)
-            User.stub(:find_or_create_by_email).with(user_params["email"]).and_yield(user).and_return(user)
+            User.stub(:find_or_create_by).with(email: user_params["email"]).and_yield(user).and_return(user)
           end
 
           specify do


### PR DESCRIPTION
At Rails 4.0, [`find_or_create_by_*` methods has been deprecated.](http://edgeguides.rubyonrails.org/4_0_release_notes.html#active-record-deprecations)
