### PR TITLE
fixes deprecations on test suite - running rails 4.1, ruby 2.1.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,8 @@ group :development, :test do
   gem 'pry'
   gem 'sqlite3'
   gem 'rspec-rails', '~> 2.99.0'
+  gem 'rspec-its'
+  gem 'rspec-activemodel-mocks'
   gem 'factory_girl_rails'
   gem 'jasmine', '~> 1.3.2'
   gem 'capybara'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,11 +153,18 @@ GEM
       rspec-core (~> 2.99.0)
       rspec-expectations (~> 2.99.0)
       rspec-mocks (~> 2.99.0)
+    rspec-activemodel-mocks (1.0.1)
+      activemodel (>= 3.0)
+      activesupport (>= 3.0)
+      rspec-mocks (>= 2.99, < 4.0)
     rspec-collection_matchers (1.0.0)
       rspec-expectations (>= 2.99.0.beta1)
     rspec-core (2.99.1)
     rspec-expectations (2.99.2)
       diff-lcs (>= 1.1.3, < 2.0)
+    rspec-its (1.0.1)
+      rspec-core (>= 2.99.0.beta1)
+      rspec-expectations (>= 2.99.0.beta1)
     rspec-mocks (2.99.2)
     rspec-rails (2.99.0)
       actionpack (>= 3.0)
@@ -236,6 +243,8 @@ DEPENDENCIES
   rails-i18n
   rails-observers (~> 0.1.2)
   rails_12factor
+  rspec-activemodel-mocks
+  rspec-its
   rspec-rails (~> 2.99.0)
   sass-rails (~> 4.0.3)
   sqlite3

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -87,7 +87,7 @@ describe UsersController do
             post :create, :project_id => project.id, :user => user_params
             user.name.should == user_params["name"]
             user.initials.should == user_params["initials"]
-            user.was_created.should be_true
+            user.was_created.should be true
             response.should redirect_to(project_users_url(project))
           end
 
@@ -114,7 +114,7 @@ describe UsersController do
 
           specify do
             post :create, :project_id => project.id, :user => user_params
-            user.was_created.should be_false
+            user.was_created.should be_falsey
           end
         end
 

--- a/spec/models/changeset_spec.rb
+++ b/spec/models/changeset_spec.rb
@@ -6,7 +6,8 @@ describe Changeset do
 
     it "must have a story" do
       subject.story = nil
-      subject.should have(1).error_on(:story)
+      subject.valid?
+      expect(subject.errors[:story].size).to eq(1)
     end
 
     describe "associations" do
@@ -18,12 +19,14 @@ describe Changeset do
 
       it "must have a valid project" do
         changeset.project_id = "invalid"
-        changeset.should have(1).errors_on(:project)
+        changeset.valid?
+        expect(changeset.errors[:project].size).to eq(1)
       end
 
       it "must have a valid story" do
         changeset.story_id = "invalid"
-        changeset.should have(1).errors_on(:story)
+        changeset.valid?
+        expect(changeset.errors[:story].size).to eq(1)
       end
     end
   end
@@ -41,7 +44,11 @@ describe Changeset do
         FactoryGirl.create :changeset, :story => story, :project => nil
       end
 
-      it { should have(0).errors_on(:project) }
+      it "shouldn't have any errors on project" do
+        story.valid?
+        expect(story.errors[:project].size).to eq(0)
+      end
+
       its(:project) { should == project }
 
     end

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -12,7 +12,10 @@ describe Note do
 
     describe "#name" do
       before { subject.note = '' }
-      it { should have(1).error_on(:note) }
+      it "should have an error on note" do
+        subject.valid?
+        expect(subject.errors[:note].size).to eq(1)
+      end
     end
 
   end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -10,57 +10,71 @@ describe Project do
 
     describe "#name" do
       before { subject.name = '' }
-      it { should have(1).error_on(:name) }
+      it "should have an error on name" do
+        subject.valid?
+        expect(subject.errors[:name].size).to eq(1)
+      end
     end
 
     describe "#default_velocity" do
       it "must be greater than 0" do
         subject.default_velocity = 0
-        subject.should have(1).error_on(:default_velocity)
+        subject.valid?
+        expect(subject.errors[:default_velocity].size).to eq(1)
       end
 
       it "must be an integer" do
         subject.default_velocity = 0
-        subject.should have(1).error_on(:default_velocity)
+        subject.valid?
+        expect(subject.errors[:default_velocity].size).to eq(1)
       end
     end
 
     describe "#point_scale" do
       before { subject.point_scale = 'invalid_point_scale' }
-      it { should have(1).error_on(:point_scale) }
+      it "has an error on point scale" do
+        subject.valid?
+        expect(subject.errors[:point_scale].size).to eq(1)
+      end
     end
 
     describe "#iteration_length" do
       it "must be greater than 0" do
         subject.iteration_length = 0
-        subject.should have(1).error_on(:iteration_length)
+        subject.valid?
+        expect(subject.errors[:iteration_length].size).to eq(1)
       end
 
       it "must be less than 5" do
         subject.iteration_length = 0
-        subject.should have(1).error_on(:iteration_length)
+        subject.valid?
+        expect(subject.errors[:iteration_length].size).to eq(1)
       end
 
       it "must be an integer" do
         subject.iteration_length = 2.5
-        subject.should have(1).error_on(:iteration_length)
+        subject.valid?
+        expect(subject.errors[:iteration_length].size).to eq(1)
       end
     end
 
     describe "#iteration_start_day" do
       it "must be greater than -1" do
         subject.iteration_start_day = -1
-        subject.should have(1).error_on(:iteration_start_day)
+        subject.valid?
+        expect(subject.errors[:iteration_start_day].size).to eq(1)
       end
 
       it "must be less than 6" do
         subject.iteration_start_day = 7
-        subject.should have(1).error_on(:iteration_start_day)
+        subject.valid?
+        expect(subject.errors[:iteration_start_day].size).to eq(1)
       end
 
       it "must be an integer" do
         subject.iteration_start_day = 2.5
-        subject.should have(1).error_on(:iteration_start_day)
+        subject.valid?
+        expect(subject.errors[:iteration_start_day].size).to eq(1)
       end
     end
 

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -9,43 +9,50 @@ describe Story do
     describe '#title' do
       it "is required" do
         subject.title = ''
-        subject.should have(1).error_on(:title)
+        subject.valid?
+        expect(subject.errors[:title].size).to eq(1)
       end
     end
 
     describe '#story_type' do
       it "is required" do
         subject.story_type = nil
-        subject.should have(1).error_on(:story_type)
+        subject.valid?
+        expect(subject.errors[:story_type].size).to eq(1)
       end
 
       it "is must be a valid story type" do
         subject.story_type = 'flum'
-        subject.should have(1).error_on(:story_type)
+        subject.valid?
+        expect(subject.errors[:story_type].size).to eq(1)
       end
     end
 
     describe '#state' do
       it "must be a valid state" do
         subject.state = 'flum'
-        subject.should have(1).error_on(:state)
+        subject.valid?
+        expect(subject.errors[:state].size).to eq(1)
       end
     end
 
     describe "#project" do
       it "cannot be nil" do
         subject.project_id = nil
-        subject.should have(1).error_on(:project)
+        subject.valid?
+        expect(subject.errors[:project].size).to eq(1)
       end
 
       it "must have a valid project_id" do
         subject.project_id = "invalid"
-        subject.should have(1).error_on(:project)
+        subject.valid?
+        expect(subject.errors[:project].size).to eq(1)
       end
 
       it "must have a project" do
         subject.project =  nil
-        subject.should have(1).error_on(:project)
+        subject.valid?
+        expect(subject.errors[:project].size).to eq(1)
       end
     end
 
@@ -53,7 +60,8 @@ describe Story do
       it "must be valid for the project point scale" do
         subject.project.point_scale = 'fibonacci'
         subject.estimate = 4 # not in the fibonacci series
-        subject.should have(1).error_on(:estimate)
+        subject.valid?
+        expect(subject.errors[:estimate].size).to eq(1)
       end
     end
 
@@ -133,7 +141,7 @@ describe Story do
       before { subject.position = 42 }
 
       it "does nothing" do
-        subject.set_position_to_last.should be_true
+        subject.set_position_to_last.should be true
         subject.position = 42
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,12 +6,14 @@ describe User do
     
     it "requires a name" do
       subject.name = ''
-      subject.should have(1).error_on(:name)
+      subject.valid?
+      expect(subject.errors[:name].size).to eq(1)
     end
 
     it "requires initials" do
       subject.initials = ''
-      subject.should have(1).error_on(:initials)
+      subject.valid?
+      expect(subject.errors[:initials].size).to eq(1)
     end
 
   end


### PR DESCRIPTION
The test suite was raising a bunch of deprecation warnings for rails 4.1 and ruby 2.1.2 so I modernized all of the calls to fit the new conventions. 