### PR TITLE
Some JS code refactor

### DIFF
--- a/app/assets/javascripts/mixins/shared_model_methods.js
+++ b/app/assets/javascripts/mixins/shared_model_methods.js
@@ -19,13 +19,13 @@ Fulcrum.SharedModelMethods = {
   },
 
   hasErrors: function() {
-    return (typeof this.get('errors') != "undefined");
+    return (!_.isUndefined(this.get('errors')));
   },
 
   errorsOn: function(field) {
     if (!this.hasErrors()) {
       return false;
     }
-    return (typeof this.get('errors')[field] != "undefined");
+    return (!_.isUndefined(this.get('errors')[field]));
   }
 };

--- a/app/assets/javascripts/models/project.js
+++ b/app/assets/javascripts/models/project.js
@@ -175,7 +175,7 @@ Fulcrum.Project = Backbone.Model.extend({
   // value is different to the calculated velocity, the velocityIsFake
   // attribute will be set to true.
   velocity: function(userVelocity) {
-    if(userVelocity !== undefined) {
+    if(!_.isUndefined(userVelocity)) {
 
       if(userVelocity < 1) {
         userVelocity = 1;
@@ -195,7 +195,7 @@ Fulcrum.Project = Backbone.Model.extend({
   },
 
   velocityIsFake: function() {
-    return (this.get('userVelocity') !== undefined);
+    return (!_.isUndefined(this.get('userVelocity')));
   },
 
   calculateVelocity: function() {

--- a/app/assets/javascripts/models/project.js
+++ b/app/assets/javascripts/models/project.js
@@ -60,11 +60,11 @@ Fulcrum.Project = Backbone.Model.extend({
   // to be loaded.
   updateChangesets: function() {
     var from = this.previous('last_changeset_id');
-    if (from === null) {
+    if (_.isNull(from)) {
       from = 0;
     }
     var to = this.get('last_changeset_id');
-    if (to === null) {
+    if (_.isNull(to)) {
       to = 0;
     }
 

--- a/app/assets/javascripts/models/story.js
+++ b/app/assets/javascripts/models/story.js
@@ -117,7 +117,7 @@ Fulcrum.Story = Backbone.Model.extend({
 
   estimated: function() {
     var estimate = this.get('estimate');
-    return !(estimate === undefined || estimate === null);
+    return !(estimate === undefined || _.isNull(estimate));
   },
 
   point_values: function() {

--- a/app/assets/javascripts/models/story.js
+++ b/app/assets/javascripts/models/story.js
@@ -200,7 +200,7 @@ Fulcrum.Story = Backbone.Model.extend({
   },
 
   hasDetails: function() {
-    return (typeof this.get('description') == "string" || this.hasNotes());
+    return (_.isString(this.get('description')) || this.hasNotes());
   },
 
   iterationNumber: function() {
@@ -223,7 +223,7 @@ Fulcrum.Story = Backbone.Model.extend({
   },
 
   labels: function() {
-    if (typeof this.get('labels') != 'string') {
+    if (!_.isString(this.get('labels'))) {
       return [];
     }
     return _.map(this.get('labels').split(','), function(label) {

--- a/app/assets/javascripts/models/story.js
+++ b/app/assets/javascripts/models/story.js
@@ -117,7 +117,7 @@ Fulcrum.Story = Backbone.Model.extend({
 
   estimated: function() {
     var estimate = this.get('estimate');
-    return !(estimate === undefined || _.isNull(estimate));
+    return !(_.isUndefined(estimate) || _.isNull(estimate));
   },
 
   point_values: function() {

--- a/app/assets/javascripts/views/project_view.js
+++ b/app/assets/javascripts/views/project_view.js
@@ -30,7 +30,7 @@ Fulcrum.ProjectView = Backbone.View.extend({
     // is bound on a collection, the callback sends the collection as the
     // second argument, so also check that column is a string and not an
     // object for those cases.
-    if (typeof column === 'undefined' || typeof column !== 'string') {
+    if (typeof column === 'undefined' || !_.isString(column)) {
       column = story.column;
     }
     var view = new Fulcrum.StoryView({model: story}).render();

--- a/app/assets/javascripts/views/project_view.js
+++ b/app/assets/javascripts/views/project_view.js
@@ -30,7 +30,7 @@ Fulcrum.ProjectView = Backbone.View.extend({
     // is bound on a collection, the callback sends the collection as the
     // second argument, so also check that column is a string and not an
     // object for those cases.
-    if (typeof column === 'undefined' || !_.isString(column)) {
+    if (_.isUndefined(column) || !_.isString(column)) {
       column = story.column;
     }
     var view = new Fulcrum.StoryView({model: story}).render();

--- a/app/assets/javascripts/views/story_view.js
+++ b/app/assets/javascripts/views/story_view.js
@@ -85,7 +85,7 @@ Fulcrum.StoryView = Fulcrum.FormView.extend({
     // If both of these are unset, the story has been dropped on an empty
     // column, which will be either the backlog or the chilly bin as these
     // are the only columns that can receive drops from other columns.
-    if (typeof previous_story_id == 'undefined' && typeof next_story_id == 'undefined') {
+    if (_.isUndefined(previous_story_id) && _.isUndefined(next_story_id)) {
 
       var beforeSearchColumns = this.model.collection.project.columnsBefore('#' + column);
       var afterSearchColumns  = this.model.collection.project.columnsAfter('#' + column);
@@ -101,9 +101,9 @@ Fulcrum.StoryView = Fulcrum.FormView.extend({
       }
     }
 
-    if (typeof previous_story_id != 'undefined') {
+    if (!_.isUndefined(previous_story_id)) {
       this.model.moveAfter(previous_story_id);
-    } else if (typeof next_story_id != 'undefined') {
+    } else if (!_.isUndefined(next_story_id)) {
       this.model.moveBefore(next_story_id);
     } else {
       // The only possible scenario that we should reach this point under


### PR DESCRIPTION
Hi, nice tool, congrats!

I was taking a look at the code in order to see how I can contribute. I noticed that in several parts of it you ask for conditionals in the following way:

typeof foo == null
typeof bar == 'string'

Underscorejs provides of several methods that are more readable, such as _.isNull and _.isString. I think that using this methods would be less error-prone too.

The intention of this pull request is to refactor the JS of the backbone app using these underscore methods.

What do you think?

Cheers!